### PR TITLE
Python 3.x on appveyor, Python 3.7 everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ python:
     - 3.4
     - 3.5
     - 3.6
+matrix:
+    include:
+        - python: 3.7
+          dist: xenial
+          sudo: true
 install:
     - pip install -U pip
     - pip install coverage coveralls -e .

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,6 @@
 Unreleased:
 
-- Support Python 3.6 (no actual code changes required).
+- Support Python 3.6 and 3.7 (no actual code changes required).
 - Drop video mode filtering by aspect ratio (21:9 monitors exist).
 
 September 21, 2016: Released version 1.1.0:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ environment:
     # https://www.appveyor.com/docs/installed-software#python lists available
     # versions
     - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
 
 init:
   - "echo %PYTHON%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,16 +12,7 @@ init:
 install:
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python --version
-  - pip install tox
-  # pygame installation cargo-culted from https://github.com/a-tal/fallingsky/blob/cae0df8eedff8be3e9e333258ff565c1f1441886/appveyor.yml
-  # only I replaced the http:// url with https://
-  # and changed version from 1.9.2a0 to 1.9.1
-  - ps: Start-FileDownload 'https://pygame.org/ftp/pygame-1.9.1.win32-py2.7.msi'
-  - ps: Start-Process -FilePath msiexec -ArgumentList /i, "pygame-1.9.1.win32-py2.7.msi", /qb, ADDLOCAL=ALL, ALLUSERS=1 -Wait
-  # For some reason pygame is installed into c:\lib\site-packages\pygame
-  # I also see c:\Miniconda-x64\Lib\site-packages\pygame, which fills me with WAT?
-  # I also see c:\PythonX\Lib\site-packages\pygame
-  - "set PYTHONPATH=c:\\Lib\\site-packages;%PYTHONPATH%"
+  - pip install -e .
   - 'python -c "import pygame; print(pygame.__version__)"'
 
 build: off

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Games/Entertainment :: Arcade',
     ],
     scripts=['pyspacewar'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36
+    py27,py34,py35,py36,py37
 
 [testenv]
 # we're going to upgrade pip, which is kind of tricky


### PR DESCRIPTION
This fills out the build matrix to be consistent between platforms and adds Python 3.7 builds everywhere.